### PR TITLE
Fixes antigens zsh-async-install

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -18,7 +18,7 @@ antigen bundles <<EOBUNDLES
 
   djui/alias-tips
 
-  mafredri/zsh-async
+  mafredri/zsh-async@main
   zsh-users/zsh-completions
   zsh-users/zsh-autosuggestions
   sindresorhus/pure@v1.5.2


### PR DESCRIPTION
 installation issue: antigen can no longer clone if there is no master branch, the fix specifies using main instead